### PR TITLE
strip http and https from msg's

### DIFF
--- a/src/digweb.coffee
+++ b/src/digweb.coffee
@@ -17,7 +17,7 @@ digwebHost = process.env.HUBOT_DIGWEB_HOST || "https://digweb.herokuapp.com"
 
 module.exports = (robot) ->
   robot.hear /^dig (.+)$/i, (msg) ->
-    data = msg.match[1]
+    data = msg.match[1].replace /^^(http|https):\/\//g, ""
     msg.http("#{digwebHost}/")
       .headers("User-Agent": "hubot-digweb")
       .post(data) (err, res, body) ->


### PR DESCRIPTION
slack auto-formats urls and adds http(s) to requests seen by this plugin. This PR makes sure http and https are stripped from the requests and fixes the issue for us.

before:

```
;; QUESTION SECTION:
;http://oxilion.nl.    IN    A
```

after:

```
;; QUESTION SECTION:
;oxilion.nl.        IN    A
```
